### PR TITLE
Första fungerande version av meshning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ ENV/
 .ropeproject
 
 # End of https://www.gitignore.io/api/python,c++
+
+
+cmake-build-debug/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(catkin REQUIRED COMPONENTS
   shape_msgs
   std_msgs
   message_generation
+  pcl_conversions
+  pcl_ros
 )
 
 ## System dependencies are found with CMake's conventions
@@ -130,16 +132,21 @@ include_directories(
 # add_dependencies(mesh_generator ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
-# add_executable(mesh_generator_node src/mesh_generator_node.cpp)
+add_executable(main src/main.cpp)
+add_executable(test_client src/test_client.cpp)
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
 # add_dependencies(mesh_generator_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-# target_link_libraries(mesh_generator_node
-#   ${catkin_LIBRARIES}
-# )
+target_link_libraries(main
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(test_client
+  ${catkin_LIBRARIES}
+)
 
 #############
 ## Install ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   pcl_conversions
   pcl_ros
+  pcl_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -49,11 +50,10 @@ find_package(catkin REQUIRED COMPONENTS
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+#add_message_files(
+#  FILES
+#  Message1.msg
+#)
 
 ## Generate services in the 'srv' folder
 add_service_files(
@@ -71,7 +71,7 @@ add_service_files(
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
   DEPENDENCIES
-  sensor_msgs shape_msgs std_msgs
+  sensor_msgs pcl_msgs std_msgs
 )
 
 ################################################
@@ -106,7 +106,7 @@ generate_messages(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES mesh_generator
-  CATKIN_DEPENDS roscpp rospy sensor_msgs shape_msgs std_msgs
+  CATKIN_DEPENDS roscpp rospy sensor_msgs pcl_msgs std_msgs
 #  DEPENDS system_lib
 )
 

--- a/package.xml
+++ b/package.xml
@@ -14,15 +14,15 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>shape_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>pcl_msgs</build_depend>
   <build_depend>message_generation</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
-  <run_depend>shape_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>pcl_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>The mesh_generator package</description>
 
-  <maintainer email="hampusdunstrom@gmail.com">Hampus Dunström</maintainer>
+  <maintainer email="martin95lundberg@gmail.com">Martin Lundberg</maintainer>
 
   <license>LGPLv3</license>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,98 @@
+#include <iostream>
+#include <pcl/point_types.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/io/vtk_io.h>
+#include <pcl/io/vtk_lib_io.h>
+#include <pcl/search/kdtree.h>
+#include <pcl/search/organized.h>
+#include <pcl/features/normal_3d_omp.h>
+#include <pcl/surface/gp3.h>
+#include <pcl/filters/passthrough.h>
+#include <pcl/filters/radius_outlier_removal.h>
+#include <pcl/surface/poisson.h>
+
+#include <ros/ros.h>
+#include <pcl_ros/point_cloud.h>
+#include "mesh_generator/MeshPointCloud.h"
+
+
+typedef mesh_generator::MeshPointCloud::Request MeshPointCloudRequest;
+typedef mesh_generator::MeshPointCloud::Response MeshPointCloudResponse;
+typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
+typedef pcl::PointCloud<pcl::Normal> NormalCloud;
+
+
+NormalCloud::Ptr estimate_normals(PointCloud::Ptr point_cloud)
+{
+    // Declare PCL objects needed to perform normal estimation
+    pcl::NormalEstimationOMP<pcl::PointXYZ, pcl::Normal> normal_estimation;
+    NormalCloud::Ptr normals(new NormalCloud);
+    pcl::search::KdTree<pcl::PointXYZ>::Ptr search_tree(new pcl::search::KdTree<pcl::PointXYZ>);
+
+    // Set input parameters for normal estimation
+    search_tree->setInputCloud(point_cloud);
+    normal_estimation.setInputCloud(point_cloud);
+    normal_estimation.setSearchMethod(search_tree);
+    normal_estimation.setKSearch(20);
+
+    // Perform normal estimation algorithm
+    normal_estimation.compute(*normals);
+
+    // Reverse the direction of all normals
+    for (size_t i = 0; i < normals->size(); ++i) {
+        normals->points[i].normal_x *= -1;
+        normals->points[i].normal_y *= -1;
+        normals->points[i].normal_z *= -1;
+    }
+
+    return normals;
+}
+
+void poisson_reconstruction(pcl::PointCloud<pcl::PointNormal>::Ptr point_cloud, pcl::PolygonMesh& mesh)
+{
+    std::cout << "Begin poisson reconstruction" << std::endl;
+
+    // Initialize poisson reconstruction
+    pcl::Poisson<pcl::PointNormal> poisson;
+    poisson.setDepth(9);
+    poisson.setInputCloud(point_cloud);
+
+    // Perform the poisson surface reconstruction algorithm
+    poisson.reconstruct(mesh);
+}
+
+bool mesh_point_cloud(MeshPointCloudRequest &request, MeshPointCloudResponse &response)
+{
+    // Mesh point cloud in request and output it through response
+    PointCloud::Ptr point_cloud(new PointCloud);
+    pcl::fromROSMsg(request.point_cloud, *point_cloud);
+
+
+    NormalCloud::Ptr normals = estimate_normals(point_cloud);
+
+    pcl::PointCloud<pcl::PointNormal>::Ptr cloud_with_normals(new pcl::PointCloud<pcl::PointNormal>);
+    pcl::concatenateFields(*point_cloud, *normals, *cloud_with_normals);
+
+    pcl::PolygonMesh mesh;
+    poisson_reconstruction(cloud_with_normals, mesh);
+
+    if (pcl::io::savePolygonFile("mesh.stl", mesh) && pcl::io::savePolygonFile("mesh.vtk", mesh)) {
+        std::cout << "Saved file successfully" << std::endl;
+    } else {
+        std::cout << "Failed to save file" << std::endl;
+    }
+
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "mesh_generator");
+
+    ros::NodeHandle node_handle;
+    ros::ServiceServer service = node_handle.advertiseService("mesh_point_cloud", mesh_point_cloud);
+    ROS_INFO("Ready to mesh point clouds");
+    ros::spin();
+
+    return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,13 +43,15 @@ NormalCloud::Ptr estimate_normals(PointCloud::Ptr point_cloud)
     normal_estimation.setInputCloud(point_cloud);
     normal_estimation.setSearchMethod(search_tree);
 
-    // When estimating normals, the algorithm looks at the nearest neighbors of every point
-    // and fits a plane to these points as close as it can. The normal of this plane is
-    // the estimated normal of the point.
-    // This sets how many of the nearest neighbors to look at when estimating normals.
-    // Is a rough setting for accuracy that can be adjusted.
-    // A lower number here means that corners in the point cloud will be more accurate,
-    // too low a number will cause problems.
+    /*
+     * When estimating normals, the algorithm looks at the nearest neighbors of every point
+     * and fits a plane to these points as close as it can. The normal of this plane is
+     * the estimated normal of the point.
+     * This sets how many of the nearest neighbors to look at when estimating normals.
+     * Is a rough setting for accuracy that can be adjusted.
+     * A lower number here means that corners in the point cloud will be more accurate,
+     * too low a number will cause problems.
+     */
     normal_estimation.setKSearch(20);
 
     // Perform normal estimation algorithm

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 //
-//
+// Module for generating meshes from point clouds
 //
 #include <vector>
 #include <pcl/point_types.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,9 +84,11 @@ void poisson_reconstruction(pcl::PointCloud<pcl::PointNormal>::Ptr point_cloud, 
     // Initialize poisson reconstruction
     pcl::Poisson<pcl::PointNormal> poisson;
 
-    // Set the maximum depth of the tree used in Poisson surface reconstruction.
-    // A higher value means more iterations which could lead to better results but
-    // it is also more computaionally heavy.
+    /*
+     * Set the maximum depth of the tree used in Poisson surface reconstruction.
+     * A higher value means more iterations which could lead to better results but
+     * it is also more computaionally heavy.
+     */
     poisson.setDepth(9);
     
     poisson.setInputCloud(point_cloud);

--- a/src/test_client.cpp
+++ b/src/test_client.cpp
@@ -1,3 +1,6 @@
+//
+// A client that calls the mesh service to test it
+//
 #include "ros/ros.h"
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
@@ -9,29 +12,29 @@ typedef mesh_generator::MeshPointCloud MeshPointCloud;
 
 int main(int argc, char **argv)
 {
-    ros::init(argc, argv, "mesh_generator_test_client");
+    ros::init(argc, argv, "mesh_generator_test_client"); //inits the node
 
     ros::NodeHandle node_handle;
     ros::ServiceClient client = node_handle.serviceClient<mesh_generator::MeshPointCloud>("mesh_point_cloud");
 
     mesh_generator::MeshPointCloud srv;
 
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>); //allocates memory to a new point cloud
     pcl::PCLPointCloud2 cloud_blob;
-    if (pcl::io::loadPCDFile("bun0.pcd", cloud_blob) == -1) {
+    if (pcl::io::loadPCDFile("bun0.pcd", cloud_blob) == -1) { // loads the file bun0.pcd into the  a tmp point cloud
         std::cout << "Couldn't read file bun0.pcd" << std::endl;
     }
-    pcl::fromPCLPointCloud2(cloud_blob, *cloud);
+    pcl::fromPCLPointCloud2(cloud_blob, *cloud); // saves the tmp point cloud cloud_blob as the point cloud cloud
 
     sensor_msgs::PointCloud2 ros_cloud;
-    pcl::toROSMsg(*cloud, ros_cloud);
+    pcl::toROSMsg(*cloud, ros_cloud); // converts the point cloud from PCL to ROS
     srv.request.point_cloud = ros_cloud;
 
     if (client.call(srv)) {
         std::cout << "Exit code: " << srv.response.exit_code << std::endl;
     }
     else {
-        ROS_ERROR("Failed to call service add_two_ints");
+        ROS_ERROR("Failed to call service mesh_point_cloud");
         return 1;
     }
 

--- a/src/test_client.cpp
+++ b/src/test_client.cpp
@@ -3,35 +3,40 @@
 //
 #include "ros/ros.h"
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
+#include <pcl/io/vtk_io.h>
+#include <pcl/io/vtk_lib_io.h>
 #include <pcl_ros/point_cloud.h>
 #include "mesh_generator/MeshPointCloud.h"
-#include <cstdlib>
 
-typedef mesh_generator::MeshPointCloud MeshPointCloud;
 
 int main(int argc, char **argv)
 {
-    ros::init(argc, argv, "mesh_generator_test_client"); //inits the node
+    ros::init(argc, argv, "mesh_generator_test_client");
 
     ros::NodeHandle node_handle;
     ros::ServiceClient client = node_handle.serviceClient<mesh_generator::MeshPointCloud>("mesh_point_cloud");
 
     mesh_generator::MeshPointCloud srv;
 
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>); //allocates memory to a new point cloud
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::PCLPointCloud2 cloud_blob;
-    if (pcl::io::loadPCDFile("bun0.pcd", cloud_blob) == -1) { // loads the file bun0.pcd into the  a tmp point cloud
+    if (pcl::io::loadPCDFile("bun0.pcd", cloud_blob) == -1) {
         std::cout << "Couldn't read file bun0.pcd" << std::endl;
     }
-    pcl::fromPCLPointCloud2(cloud_blob, *cloud); // saves the tmp point cloud cloud_blob as the point cloud cloud
+    pcl::fromPCLPointCloud2(cloud_blob, *cloud);
 
+    // Convert point cloud to a ROS message and send it in request
     sensor_msgs::PointCloud2 ros_cloud;
-    pcl::toROSMsg(*cloud, ros_cloud); // converts the point cloud from PCL to ROS
+    pcl::toROSMsg(*cloud, ros_cloud);
     srv.request.point_cloud = ros_cloud;
 
     if (client.call(srv)) {
-        std::cout << "Exit code: " << srv.response.exit_code << std::endl;
+        pcl::PolygonMesh mesh;
+        pcl_conversions::toPCL(srv.response.mesh, mesh);
+	
+        if (pcl::io::savePolygonFile("mesh-response.stl", mesh)) {
+	        ROS_INFO("Saved file mesh-response.stl");
+        }
     }
     else {
         ROS_ERROR("Failed to call service mesh_point_cloud");

--- a/src/test_client.cpp
+++ b/src/test_client.cpp
@@ -7,7 +7,7 @@
 #include <pcl/io/vtk_lib_io.h>
 #include <pcl_ros/point_cloud.h>
 #include "mesh_generator/MeshPointCloud.h"
-
+#include <sstream>
 
 int main(int argc, char **argv)
 {
@@ -18,29 +18,54 @@ int main(int argc, char **argv)
 
     mesh_generator::MeshPointCloud srv;
 
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_lamp(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_cat(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_wolf(new pcl::PointCloud<pcl::PointXYZ>);
+    
     pcl::PCLPointCloud2 cloud_blob;
-    if (pcl::io::loadPCDFile("bun0.pcd", cloud_blob) == -1) {
+    if (pcl::io::loadPCDFile("lamppost.pcd", cloud_blob) == -1) {
         std::cout << "Couldn't read file bun0.pcd" << std::endl;
     }
-    pcl::fromPCLPointCloud2(cloud_blob, *cloud);
+    pcl::fromPCLPointCloud2(cloud_blob, *cloud_lamp);
 
+    if (pcl::io::loadPCDFile("ism_test_cat.pcd", cloud_blob) == -1) {
+        std::cout << "Couldn't read file bun0.pcd" << std::endl;
+    }
+    pcl::fromPCLPointCloud2(cloud_blob, *cloud_cat);
+
+    if (pcl::io::loadPCDFile("ism_test_wolf.pcd", cloud_blob) == -1) {
+        std::cout << "Couldn't read file bun0.pcd" << std::endl;
+    }
+    pcl::fromPCLPointCloud2(cloud_blob, *cloud_wolf);
+
+    
     // Convert point cloud to a ROS message and send it in request
     sensor_msgs::PointCloud2 ros_cloud;
-    pcl::toROSMsg(*cloud, ros_cloud);
+    pcl::toROSMsg(*cloud_lamp, ros_cloud);
     srv.request.point_cloud = ros_cloud;
 
-    if (client.call(srv)) {
-        pcl::PolygonMesh mesh;
-        pcl_conversions::toPCL(srv.response.mesh, mesh);
-	
-        if (pcl::io::savePolygonFile("mesh-response.stl", mesh)) {
-	        ROS_INFO("Saved file mesh-response.stl");
-        }
-    }
-    else {
-        ROS_ERROR("Failed to call service mesh_point_cloud");
-        return 1;
+    for (size_t i = 0; i < 3; ++i) {
+        if (client.call(srv)) {
+	    pcl::PolygonMesh mesh;
+	    pcl_conversions::toPCL(srv.response.mesh, mesh);
+
+	    std::stringstream file_name;
+	    file_name << "mesh-response" << i << ".stl";
+	    if (pcl::io::savePolygonFile(file_name.str(), mesh)) {
+	        ROS_INFO("Saved file mesh-responseX.stl");
+	    }
+
+	    if (i == 0) {
+	        pcl::toROSMsg(*cloud_cat, ros_cloud);
+		srv.request.point_cloud = ros_cloud;
+	    } else if (i == 1) {
+	        pcl::toROSMsg(*cloud_wolf, ros_cloud);
+		srv.request.point_cloud = ros_cloud;
+	    }
+	} else {
+	    ROS_ERROR("Failed to call service mesh_point_cloud");
+            return 1;
+	}
     }
 
     return 0;

--- a/src/test_client.cpp
+++ b/src/test_client.cpp
@@ -1,5 +1,7 @@
 //
 // A client that calls the mesh service to test it
+// Needs the files lamppost.pcd, ism_test_cat.pcd and ism_test_wolf.pcd
+// to send to the meshing service
 //
 #include "ros/ros.h"
 #include <pcl/io/pcd_io.h>

--- a/src/test_client.cpp
+++ b/src/test_client.cpp
@@ -1,0 +1,39 @@
+#include "ros/ros.h"
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl_ros/point_cloud.h>
+#include "mesh_generator/MeshPointCloud.h"
+#include <cstdlib>
+
+typedef mesh_generator::MeshPointCloud MeshPointCloud;
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "mesh_generator_test_client");
+
+    ros::NodeHandle node_handle;
+    ros::ServiceClient client = node_handle.serviceClient<mesh_generator::MeshPointCloud>("mesh_point_cloud");
+
+    mesh_generator::MeshPointCloud srv;
+
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PCLPointCloud2 cloud_blob;
+    if (pcl::io::loadPCDFile("bun0.pcd", cloud_blob) == -1) {
+        std::cout << "Couldn't read file bun0.pcd" << std::endl;
+    }
+    pcl::fromPCLPointCloud2(cloud_blob, *cloud);
+
+    sensor_msgs::PointCloud2 ros_cloud;
+    pcl::toROSMsg(*cloud, ros_cloud);
+    srv.request.point_cloud = ros_cloud;
+
+    if (client.call(srv)) {
+        std::cout << "Exit code: " << srv.response.exit_code << std::endl;
+    }
+    else {
+        ROS_ERROR("Failed to call service add_two_ints");
+        return 1;
+    }
+
+    return 0;
+}

--- a/srv/MeshPointCloud.srv
+++ b/srv/MeshPointCloud.srv
@@ -1,5 +1,5 @@
 sensor_msgs/PointCloud2 point_cloud
 ---
-shape_msgs/Mesh mesh
+pcl_msgs/PolygonMesh mesh
 int16 exit_code
 string error_message


### PR DESCRIPTION
Nu fungerar meshning av punktmoln. main fungerar som en service som estimerar normaler till ett punktmoln och använder sedan Poisson surface reconstruction för att skapa en mesh.

test_client kan användas för att testa servicen. Den läser in punktmoln från filer och skickar till servicen och sparar den mesh den får tillbaka till .stl-filer.

Har testats med filerna lamppost.pcd, ism_test_cat.pcd och ism_test_wolf.pcd från https://github.com/PointCloudLibrary/data . Alla filerna fungerar men blir inte helt korrekta. Det kan bero på att filerna har för få punkter. Vi kommer behöva testa med våra egna punktmoln och justera parametrar för att få det att fungera bra men just nu fungerar meshningen i alla fall.